### PR TITLE
gulpファイルの修正

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,4 +1,4 @@
-const tasks = {
+var tasks = {
   svg: {
     plugins: [
       { removeEmptyAttrs:  true },

--- a/config.js
+++ b/config.js
@@ -1,0 +1,43 @@
+const tasks = {
+  svg: {
+    plugins: [
+      { removeEmptyAttrs:  true },
+      { removeEmptyText:  true },
+      { removeEmptyContainers:  true },
+      { cleanupAttrs:  false },
+      { removeDoctype:  false },
+      { removeXMLProcInst:  false },
+      { removeComments:  false },
+      { removeMetadata:  false },
+      { removeTitle :  false },
+      { removeDesc:  false },
+      { removeUselessDefs:  false },
+      { removeXMLNS:  false },
+      { removeEditorsNSData :  false },
+      { removeHiddenElems:  false },
+      { removeViewBox:  false },
+      { cleanupEnableBackground:  false },
+      { minifyStyles:  false },
+      { convertStyleToAttrs:  false },
+      { convertColors:  false },
+      { convertPathData:  false },
+      { convertTransform:  false },
+      { removeUnknownsAndDefaults:  false },
+      { removeNonInheritableGroupAttrs:  false },
+      { removeUselessStrokeAndFill:  false },
+      { removeUnusedNS:  false },
+      { cleanupIDs:  false },
+      { cleanupNumericValues:  false },
+      { cleanupListOfValues:  false },
+      { moveElemsAttrsToGroup:  false },
+      { moveGroupAttrsToElems:  false },
+      { collapseGroups:  false },
+      { removeRasterImages:  false },
+      { mergePaths:  false },
+      { convertShapeToPath:  false },
+      {                }
+    ]
+  }
+}
+
+module.exports = tasks

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,6 +23,6 @@ gulp.task("pngMinTask", function() {
 
 // watchタスク
 gulp.task("default", function() {
-  gulp.watch("src/**/*svg", ['svgMinTask']),
-  gulp.watch("src/**/*png", ['pngMinTask'])
+  gulp.watch("src/**/*.svg", ['svgMinTask']),
+  gulp.watch("src/**/*.png", ['pngMinTask'])
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,85 +4,25 @@ var gulp = require("gulp");
 var svgmin = require("gulp-svgmin");
 // pngを圧縮するプラグインの読み込み
 var pngmin = require("gulp-imagemin");
-// 「svgMinTask」という名前のタスクを登録
-gulp.task("minTask", function() {
-  // srcフォルダー以下のpng画像を取得
-  gulp.watch("src/**", function() {
-	  gulp.src("src/**/*.svg") 
-        .pipe(svgmin({
-            plugins: [{
-                removeEmptyAttrs:  true
-            }, {
-                removeEmptyText:  true
-            }, {
-                removeEmptyContainers:  true
-            }, {
-                cleanupAttrs:  false
-            }, {
-                removeDoctype:  false
-            }, {
-                 removeXMLProcInst:  false
-            }, {
-                removeComments:  false
-            }, {
-                removeMetadata:  false
-            }, {
-                removeTitle :  false
-            }, {
-                removeDesc:  false
-            }, {
-                removeUselessDefs:  false
-            }, {
-                removeXMLNS:  false
-            }, {
-                removeEditorsNSData :  false
-            }, {
-                 removeHiddenElems:  false
-            }, {
-                removeViewBox:  false
-            }, {
-                cleanupEnableBackground:  false
-            }, {
-                minifyStyles:  false
-            }, {
-                convertStyleToAttrs:  false
-            }, {
-                convertColors:  false
-            }, {
-                convertPathData:  false
-            }, {
-                 convertTransform:  false
-            }, {
-                removeUnknownsAndDefaults:  false
-            }, {
-                removeNonInheritableGroupAttrs:  false
-            }, {
-                removeUselessStrokeAndFill:  false
-            }, {
-                removeUnusedNS:  false
-            }, {
-                cleanupIDs:  false
-            }, {
-                cleanupNumericValues:  false
-            }, {
-                cleanupListOfValues:  false
-            }, {
-                moveElemsAttrsToGroup:  false
-            }, {
-                moveGroupAttrsToElems:  false
-            }, {
-                collapseGroups:  false
-            }, {
-                removeRasterImages:  false
-            }, {
-                mergePaths:  false
-            }, {
-                convertShapeToPath:  false
-            }, {                }]
-        })) // svgの圧縮処理を実行
-	    .pipe(gulp.dest("dist/")); //distフォルダー以下に保存
-	  gulp.src("src/**/*.png")   
-	    .pipe(pngmin()) // pngの圧縮処理を実行
-	    .pipe(gulp.dest("dist/")); //distフォルダー以下に保存
-	});
+
+var tasks = require("./config.js");
+
+// SVG圧縮タスク
+gulp.task("svgMinTask", function() {
+  return gulp.src("src/**/*.svg")
+    .pipe(svgmin(tasks.svg.plugins))
+    .pipe(gulp.dest("dist/"));
+});
+
+// png圧縮タスク
+gulp.task("pngMinTask", function() {
+  return gulp.src("src/**/*.png")
+    .pipe(pngmin()) // pngの圧縮処理を実行
+    .pipe(gulp.dest("dist/"));
+});
+
+// watchタスク
+gulp.task("default", function() {
+  gulp.watch("src/**/*svg", ['svgMinTask']),
+  gulp.watch("src/**/*png", ['pngMinTask'])
 });


### PR DESCRIPTION
現状のコードの範囲でgulpフィイルを修正してみました。

タスクを別々に書いて、watchでまとめると、後々タスクが増えた時に修正しやすいです。
オプションや設定系はconfig.js作って、そこに書くとスッキリします。

このコマンドで実行できます
```
// デフォルト（watch）タスク
gulp

// svg圧縮
gulp svgMinTask

// png圧縮
gulp pngMinTask
```

あと、これやった方がいいなと思うのが、

* いらなくなった画像をsrcディレクトリ以下から消した場合distには残ってしまう
* watchでタスクが動くようになってるので、画像を追加したり編集したり、何かしらやらないとタスクが実行されない

っていうのがあるので、やってみるといいと思います。
一応手作業で、distから削除したり、`gulp svgMinTask`で個別にタスク実行することはできるので、絶対やった方がいいいうわけではないですが。